### PR TITLE
Forward to `ember-cli` when using `npx`, but keep behavior the same otherwise.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+my-app/
+node_modules/

--- a/index.js
+++ b/index.js
@@ -1,10 +1,33 @@
-console.log('====================================================================');
+const { spawn } = require('child_process');
+const [_node, _bin, ...args] = process.argv;
+
+if (args.includes('--postinstall')) {
+  console.log(
+    '===================================================================='
+  );
+  console.log('');
+  console.log(
+    '  The `ember` node module is a placeholder, you may be looking for:'
+  );
+  console.log('');
+  console.log('  * `ember-cli` (the command line tool) ');
+  console.log('  * `ember-source` (the framework code) ');
+  console.log('');
+  console.log('  Visit https://emberjs.com/ for more details');
+  console.log('');
+  console.log(
+    '===================================================================='
+  );
+
+  return;
+}
+
 console.log('');
-console.log('  The `ember` node module is a placeholder, you may be looking for:');
-console.log('');
-console.log('  * `ember-cli` (the command line tool) ');
-console.log('  * `ember-source` (the framework code) ');
-console.log('');
-console.log('  Visit http://emberjs.com/ for more details');
-console.log('');
-console.log('====================================================================');
+console.log(
+  `  Forwarding request to ember-cli via \`npx ember-cli ${args.join(' ')}\``
+);
+
+spawn('npx', ['ember-cli', ...args], {
+  stdio: 'inherit',
+  env: { ...process.env },
+});

--- a/index.js
+++ b/index.js
@@ -29,5 +29,4 @@ console.log(
 
 spawn('npx', ['ember-cli', ...args], {
   stdio: 'inherit',
-  env: { ...process.env },
-});
+}).on('exit', code => process.exit(code));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A framework for creating ambitious web applications.",
   "main": "index.js",
   "scripts": {
-    "postinstall": "node ./index.js"
+    "postinstall": "node ./index.js --postinstall",
+    "test": "rm -rf ./my-app/; node ./index.js",
+    "test:app": "npm run test -- new my-app --skip-git --skip-npm"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
For the last couple years, using `npx`, `pnpx`, (etc), are very good and popular ways to set up a project without having to install additional tooling on one's system.

Folks regularly try `npx ember`, only to find out that it doesn't work.

We still want folks to use `ember-cli`, but we can help out folks by helping them to to their tasks that matter by forwarding whatever args folks try to `npx ember` and forward them to `npx ember-cli`