### PR TITLE
Make 'use ember-cli' messaging more aggressive

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,25 @@
 const { spawn } = require('child_process');
 const [_node, _bin, ...args] = process.argv;
 
-if (args.includes('--postinstall')) {
-  console.log(
-    '===================================================================='
-  );
-  console.log('');
-  console.log(
-    '  The `ember` node module is a placeholder, you may be looking for:'
-  );
-  console.log('');
-  console.log('  * `ember-cli` (the command line tool) ');
-  console.log('  * `ember-source` (the framework code) ');
-  console.log('');
-  console.log('  Visit https://emberjs.com/ for more details');
-  console.log('');
-  console.log(
-    '===================================================================='
-  );
+console.log(
+  '===================================================================='
+);
+console.log('');
+console.log(
+  '  The `ember` node module is a placeholder, you may be looking for:'
+);
+console.log('');
+console.log('  * `ember-cli` (the command line tool) ');
+console.log('  * `ember-source` (the framework code) ');
+console.log('');
+console.log('  Visit https://emberjs.com/ for more details');
+console.log('');
+console.log(
+  '===================================================================='
+);
 
+
+if (args.includes('--postinstall')) {
   return;
 }
 


### PR DESCRIPTION
As a follow up to https://github.com/emberjs/ember/pull/4
and as a continuation of "be more friendly and help people be productive without error" (goals of #4)

Previously
![image](https://github.com/emberjs/ember/assets/199018/6fb67f39-f7b5-4178-bdfa-943be7f3b8da)

Now
![image](https://github.com/emberjs/ember/assets/199018/93fcfdf0-f48f-4ca2-b622-5edda61acc89)
(not that my invocations of `ember` are _with_ the changes from #6 as well)

This was realized after messing with the new release 1.1.0, and that I _could_ not get any postinstall script to run (even if just an echo).

Today, I've found out, that on the machine i'm using:
```
npm install -g ember
```
does trigger any postinstall behavior whatsover. I could not figure out why, after reading the docs on install and `ignore-scripts` behavior. Maybe a volta issue?

To be extra sure I remove volta from my system, `rm -rf ~/.volta`, and installed `npm` via `brew`.
`npm install -g ember` no dice. (same with the previous versions, to be extra sure, `npm install -g ember@1.0.0`, `npm install -g ember@1.0.1`) -- all with `ignore-scripts=false` (not my default).


So anywho, postinstall seems to potentially be unrilable (across two machines of mine) it's possible that "something" has happened to the defaults -- but I think for the better? (for security, because that's a good thing to do, ignore-scripts=true should be default)

In any case, regardless of whether or not `postinstall` works on different machines, I think it would be good to print the same message right before forwarding to ember-cli.


